### PR TITLE
Make vgcfgbackup_output work on Ruby 1.9 and later

### DIFF
--- a/lib/lvm/vg_config.rb
+++ b/lib/lvm/vg_config.rb
@@ -57,13 +57,15 @@ class LVM::VGConfig
 				cmd = "#{@vgcfgbackup_cmd} -f #{tmpf.path} #{@vg_name}"
 				stdout = nil
 				stderr = nil
-				Open3.popen3(cmd) do |stdin_fd, stdout_fd, stderr_fd|
+				exit_status = nil
+				Open3.popen3(cmd) do |stdin_fd, stdout_fd, stderr_fd, thr|
 					stdin_fd.close
 					stdout = stdout_fd.read
 					stderr = stderr_fd.read
+					exit_status = thr.value if thr
 				end
 
-				if $?.exitstatus != 0
+				if ($? ? $?.exitstatus : exit_status) != 0
 					raise RuntimeError,
 					      "Failed to run vgcfgbackup: #{stdout}\n#{stderr}"
 				end


### PR DESCRIPTION
da00c95 fixed the behaviour of vgcfgbackup_output to work with Ruby
1.8's popen3, but this had the side effect of breaking it on 1.9 and
later. This patch allows it to work with either form of popen3.
