### PR TITLE
Fix for VG/LV names containing hyphens

### DIFF
--- a/lib/lvm/snapshot.rb
+++ b/lib/lvm/snapshot.rb
@@ -108,6 +108,6 @@ class LVM::Snapshot
 	end
 
 	def metadata_device
-		"/dev/mapper/#{@vg}-#{@lv}-cow"
+		"/dev/mapper/#{@vg.gsub('-', '--')}-#{@lv.gsub('-', '--')}-cow"
 	end
 end

--- a/lib/vgcfgbackup.treetop
+++ b/lib/vgcfgbackup.treetop
@@ -8,7 +8,7 @@ grammar VgCfgBackup
 	end
 
 	rule variable_name
-		[a-z0-9_]+ <VariableName>
+		[a-z0-9_\-]+ <VariableName>
 	end
 
 	rule group


### PR DESCRIPTION
This patch both adds a hyphen to the allowed characters for a variable
name in the vgcfgbackup parser, and correctly translates hyphenated
VG/LV names into COW device names.
