### PR TITLE
Add a --readfrom option to specify the source device

### DIFF
--- a/bin/lvmsync
+++ b/bin/lvmsync
@@ -50,6 +50,9 @@ def main()
 		opts.on("-s", "--stdout", "Write output data to stdout rather than another lvmsync process") do |v|
 			options[:stdout] = true
 		end
+		opts.on("-r", "--readfrom <lv>", "Name of the LV to read from; defaults to the origin of the snapshot given") do |v|
+			options[:readfrom] = v
+		end
 	end.parse!
 
 	if options[:apply]
@@ -147,6 +150,7 @@ def run_client(opts)
 	snapshot = opts[:snapdev]
 	desthost = opts[:desthost]
 	destdev = opts[:destdev]
+	readfrom = opts[:readfrom]
 	outfd = nil
 
 	vg, lv = parse_snapshot_name(snapshot)
@@ -160,9 +164,9 @@ def run_client(opts)
 
 	snap = if vgconfig.logical_volumes[lv].snapshot?
 		if vgconfig.logical_volumes[lv].thin?
-			LVM::ThinSnapshot.new(vg, lv)
+			LVM::ThinSnapshot.new(vg, lv, readfrom)
 		else
-			LVM::Snapshot.new(vg, lv)
+			LVM::Snapshot.new(vg, lv, readfrom)
 		end
 	else
 		$stderr.puts "#{snapshot}: Not a snapshot device"

--- a/lib/lvm/snapshot.rb
+++ b/lib/lvm/snapshot.rb
@@ -6,9 +6,17 @@ module LVM; end
 class LVM::Snapshot
 	include LVM::Helpers
 
-	def initialize(vg, lv)
+	def initialize(vg, lv, source_lv = nil)
 		@vg = vg
 		@lv = lv
+		if source_lv
+			begin
+				@origin = vgcfg.logical_volumes[source_lv].name
+			rescue
+				raise RuntimeError,
+					"#{@vg}/#{@lv}: Unable to find source device #{@vg}/#{source_lv}"
+			end
+		end
 	end
 
 	# Return an array of ranges which are the bytes which are different
@@ -72,7 +80,7 @@ class LVM::Snapshot
 
 	def origin
 		# Man old-skool snapshots are weird
-		vgcfg.logical_volumes.values.find { |lv| lv.cow_store == @lv }.origin
+		@origin ||= vgcfg.logical_volumes.values.find { |lv| lv.cow_store == @lv }.origin
 	end
 
 	private

--- a/lib/lvm/thin_snapshot.rb
+++ b/lib/lvm/thin_snapshot.rb
@@ -3,9 +3,17 @@ require 'rexml/document'
 module LVM; end
 
 class LVM::ThinSnapshot
-	def initialize(vg, lv)
+	def initialize(vg, lv, source_lv = nil)
 		@vg = vg
 		@lv = lv
+		if source_lv
+			begin
+				@origin = vgcfg.logical_volumes[source_lv].name
+			rescue
+				raise RuntimeError,
+					"#{@vg}/#{@lv}: Unable to find source device #{@vg}/#{source_lv}"
+			end
+		end
 	end
 
 	# Return an array of ranges which are the bytes which are different


### PR DESCRIPTION
Instead of always reading from the origin volume, let the user specify
which device to use for reading. This enables reading the differences
between two snapshots, allowing the origin to continue being actively
used while still getting a consistent image.
