### PR TITLE
Fix the block maps for data ranges

### DIFF
--- a/lib/lvm/thin_snapshot.rb
+++ b/lib/lvm/thin_snapshot.rb
@@ -172,7 +172,7 @@ class LVM::ThinSnapshot
 						len = r.attribute('length').value.to_i
 						ori = r.attribute('origin_begin').value.to_i
 						dat = r.attribute('data_begin').value.to_i
-						h2[(dat..dat+len-1)] = (ori..ori+len-1)
+						h2[(ori..ori+len-1)] = (dat..dat+len-1)
 					end
 
 					h2


### PR DESCRIPTION
The existing code uses the underlying data blocks as keys, and the
origin blocks as values, which is backwards. This is done correctly
above for the single mapping case, so this bug only affects range
mappings.
