### PR TITLE
Parse the output of thin_dump line by line

### DIFF
--- a/lib/lvm/snapshot.rb
+++ b/lib/lvm/snapshot.rb
@@ -1,4 +1,3 @@
-require 'rexml/document'
 require 'lvm/helpers'
 
 module LVM; end


### PR DESCRIPTION
For large volumes, the output of thin_dump can be tens of megabytes in
size, resulting in enormous memory usage when attempting to parse the
entire document as XML at once. This solution is less elegant, but it
gets the job done much more efficiently by regex matching one line at a
time.

This pull request contains a reimplementation of the code changed in [0],
so I will be closing that pull request shortly.

[0] https://github.com/mpalmer/lvmsync/pull/18
