### PR TITLE
Fix parser crash when LV stripes > 1

### DIFF
--- a/lib/vgcfgbackup.treetop
+++ b/lib/vgcfgbackup.treetop
@@ -24,7 +24,7 @@ grammar VgCfgBackup
 	end
 
 	rule list
-		"[" space? ((string / integer) ", " / (string / integer))* space? "]" <List>
+		"[" space? ((string / integer) "," space? / (string / integer))* space? "]" <List>
 	end
 
 	rule space


### PR DESCRIPTION
I really banged my head against this one.

When running the command `lvmsync /dev/lvm/leipzig.vmmigrate.1424707061 tianjin:/dev/lvm/test`, I kept getting the following message:

```
FATAL ERROR: /dev/lvm/leipzig.vmmigrate.1424707061: could not find logical volume (Cannot parse vgcfgbackup output: Expected one of [0-9], , , ", [1-9], 0, [\s], ] at line 100, column 18 (byte 2026) after lvm {
        id = "p2Kp2s-eCDp-MIJU-dars-6gwU-uYjr-wVwPhO"
<lines snipped>
        logical_volumes {
<lines snipped>
                vserver05 {
                        id = "YEQGFk-zWzO-dAwr-89ab-o5Pw-aZH5-UqPhMC"
                        status = ["READ", "WRITE", "VISIBLE"]
                        flags = []
                        segment_count = 2

                        segment1 {
                                start_extent = 0
                                extent_count = 20480    # 80 Gigabytes

                                type = "striped"
                                stripe_count = 2
                                stripe_size = 128       # 64 Kilobytes

                                stripes = [
                                        "pv0", 43494)
```

The full message along with the dump file created by `vgcfgbackup` is at https://gist.github.com/sjbronner/bc6478b9756a94106ca1.

I went on several wild goose chases trying to find an error in the *code* of lvmsync and/or treetop. In the end, I finally understood how treetop worked enough to guess at what the entries in `vgcfgbackup.treetop` should do. And then it glared in my face: The list of physical volumes behind a logical volume was separated by `",\n"`, not by `", "`, as specified there.